### PR TITLE
feature: hosted checkout to v3 forms and scaffold subscription module

### DIFF
--- a/easymerchant-givewp/class-easymerchant-gateway-subscription-module.php
+++ b/easymerchant-givewp/class-easymerchant-gateway-subscription-module.php
@@ -32,6 +32,8 @@ class EasyMerchantGatewaySubscriptionModule extends SubscriptionModule
             if ($hostedCheckout){
                 $chargeId = give_clean($gatewayData['easymerchant-charge-id']);
                 // TODO: this would need to be implemented from the hosted checkout
+                // some gateways will use the initial chargeID and continue creating the subscription on the server.
+                // not sure how easy merchant handles this.
                 $subscriptionId = give_clean($gatewayData['easymerchant-subscription-id']);
 
                 if (empty($chargeId)) {
@@ -163,7 +165,6 @@ class EasyMerchantGatewaySubscriptionModule extends SubscriptionModule
             ),
         ));
         $response = json_decode(curl_exec($curl), true);
-        ray($response);
         // Check for cURL errors
         if (curl_errno($curl)) {
             throw new Exception('cURL error: ' . curl_error($curl));

--- a/easymerchant-givewp/class-easymerchant-gateway-subscription-module.php
+++ b/easymerchant-givewp/class-easymerchant-gateway-subscription-module.php
@@ -4,105 +4,45 @@ use Give\Donations\Models\Donation;
 use Give\Donations\Models\DonationNote;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\Exceptions\Primitives\Exception;
-use Give\Framework\PaymentGateways\Commands\GatewayCommand;
-use Give\Framework\PaymentGateways\Commands\PaymentComplete;
-use Give\Framework\PaymentGateways\Commands\PaymentRefunded;
+use Give\Framework\PaymentGateways\Commands\SubscriptionComplete;
 use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
-use Give\Framework\PaymentGateways\PaymentGateway;
+use Give\Framework\PaymentGateways\SubscriptionModule;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 
 /**
  * @inheritDoc
  */
-class EasyMerchantGateway extends PaymentGateway
+class EasyMerchantGatewaySubscriptionModule extends SubscriptionModule
 {
     /**
-     * @inheritDoc
+     * @inerhitDoc
+     *
+     * @throws Exception|PaymentGatewayException
      */
-    public static function id(): string
-    {
-        return 'easymerchant-gateway';
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getId(): string
-    {
-        return self::id();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getName(): string
-    {
-        return __('EasyMerchant', 'easymerchant-givewp');
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getPaymentMethodLabel(): string
-    {
-        return __('EasyMerchant', 'easymerchant-givewp');
-    }
-
-    /**
-     * Display gateway fields for v2 donation forms
-     */
-    public function getLegacyFormFieldMarkup(int $formId, array $args): string
-    {
-        // Step 1: add any gateway fields to the form using html.  In order to retrieve this data later the name of the input must be inside the key gatewayData (name='gatewayData[input_name]').
-        // Step 2: you can alternatively send this data to the $gatewayData param using the filter `givewp_create_payment_gateway_data_{gatewayId}`
-        // return easymerchant_output_redirect_notice($formId, $args);
-        $output1 = easymerchant_output_redirect_notice($formId, $args);
-
-        // Call the second function
-        $output2 = easymerchant_givewp_custom_credit_card_form($formId);
-
-        // Concatenate the results or use any other logic based on your requirements
-        $result = $output1 . $output2;
-
-        return $result;
-    }
-
-    /**
-     * Register a js file to display gateway fields for v3 donation forms
-     */
-    public function enqueueScript(int $formId)
-    {
-        wp_enqueue_script('easymerchant-gateway-api', 'https://api.easymerchant.io/assets/checkout/easyMerchant.js', [], '1.0.0', true);
-        wp_enqueue_script($this::id(), plugin_dir_url(__FILE__) . 'assets/js/easymerchant-gateway.js', ['easymerchant-gateway-api', 'react', 'wp-element', 'wp-i18n'], '1.0.0', true);
-    }
-
-    /**
-     * Send form settings to the js gateway counterpart
-     */
-    public function formSettings(int $formId): array
-    {
-        return [
-            // 'publishable_key' => 'Ow9CaBwjk23cHGakuhBDl5sj9'
-            'publishable_key' => '280066215f64af12cee5765cb'
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function createPayment(Donation $donation, $gatewayData): GatewayCommand
-    {
+    public function createSubscription(
+        Donation $donation,
+        Subscription $subscription,
+        $gatewayData
+    ) {
         try {
             $hostedCheckout = give_clean($gatewayData['easymerchant-hosted-checkout']);
 
             // first check if hosted checkout is enabled
             if ($hostedCheckout){
                 $chargeId = give_clean($gatewayData['easymerchant-charge-id']);
+                // TODO: this would need to be implemented from the hosted checkout
+                $subscriptionId = give_clean($gatewayData['easymerchant-subscription-id']);
 
                 if (empty($chargeId)) {
                     throw new PaymentGatewayException(__('EasyMerchant Charge ID is required.', 'example-give' ) );
                 }
 
-                return new PaymentComplete($chargeId);
+                if (empty($subscriptionId)) {
+                    throw new PaymentGatewayException(__('EasyMerchant Subscription ID is required.', 'example-give' ) );
+                }
+
+                return new SubscriptionComplete($chargeId, $subscriptionId);
             }
 
             // if not using hosted checkout make the request with the gateway
@@ -110,17 +50,19 @@ class EasyMerchantGateway extends PaymentGateway
                 'amount' => $donation->amount->formatToDecimal(),
                 'name' => trim("$donation->firstName $donation->lastName"),
                 'email' => $donation->email,
-                'currency' => $donation->amount->getCurrency(),
-                // TODO get from subscription model in SubscriptionModule
-                'period' => 'month',
+                'currency' => $subscription->amount->getCurrency(),
+                'period' => $subscription->period->getValue()
             ]);
 
             if (empty($response['charge_id'])) {
                 throw new PaymentGatewayException(__('EasyMerchant Charge ID is required.', 'example-give' ) );
             }
 
-            //TODO: Handle subscription ID in subscription Module $response['subscription_id'];
-            return new PaymentComplete($response['charge_id']);
+            if (empty($response['subscription_id'])) {
+                throw new PaymentGatewayException(__('EasyMerchant Subscription ID is required.', 'example-give' ) );
+            }
+
+            return new SubscriptionComplete($response['charge_id'], $response['subscription_id']);
         } catch (Exception $e) {
             // Step 4: If an error occurs, you can update the donation status to something appropriate like failed, and finally throw the PaymentGatewayException for the framework to catch the message.
             $errorMessage = $e->getMessage();
@@ -139,15 +81,30 @@ class EasyMerchantGateway extends PaymentGateway
 
     /**
      * @inerhitDoc
+     *
+     * @throws PaymentGatewayException
      */
-    public function refundDonation(Donation $donation): PaymentRefunded
+    public function cancelSubscription(Subscription $subscription)
     {
-        // Step 1: refund the donation with your gateway.
-        // Step 2: return a command to complete the refund.
-        return new PaymentRefunded();
+        try {
+            // Step 1: cancel the subscription with your gateway.
+
+            // Step 2: update the subscription status to cancelled.
+            $subscription->status = SubscriptionStatus::CANCELLED();
+            $subscription->save();
+        } catch (\Exception $exception) {
+            throw new PaymentGatewayException(
+                sprintf(
+                    'Unable to cancel subscription. %s',
+                    $exception->getMessage()
+                ),
+                $exception->getCode(),
+                $exception
+            );
+        }
     }
 
-    /**
+     /**
      * @throws Exception
      */
     private function makePaymentRequest(array $data): array
@@ -162,6 +119,15 @@ class EasyMerchantGateway extends PaymentGateway
         $year                   = $cc_info['card_exp_year'];
         $cc_cvc                 = $cc_info['card_cvc'];
         $currentDate       = date("m/d/Y");
+        $originalValues         = ["day", "week", "month", "quarter", "year"]; // API support these terms
+        $replacementValues      = ["daily", "weekly", "monthly", "quarterly", "yearly"]; //givewp support these terms
+        if (isset($data['period'])) {
+            $originalValue        = $data['period'];
+            $key                  = array_search($originalValue, $originalValues);
+            if ($key !== false) {
+                $data['period'] = $replacementValues[$key];
+            }
+        }
 
         $curl = curl_init();
         curl_setopt_array($curl, array(
@@ -186,7 +152,9 @@ class EasyMerchantGateway extends PaymentGateway
                 'exp_year'       => $year,
                 'cvc'            => $cc_cvc,
                 'cardholder_name' => $cc_holder,
-                'payment_type'   => 'charge',
+                'payment_type'   => 'recurring',
+                'interval'       => $data['period'],
+                'allowed_cycles' => 12,
             ]),
             CURLOPT_HTTPHEADER => array(
                 'X-Api-Key: doggiedaycareKxYeMhRl',

--- a/easymerchant-givewp/class-easymerchant-gateway.php
+++ b/easymerchant-givewp/class-easymerchant-gateway.php
@@ -195,7 +195,6 @@ class EasyMerchantGateway extends PaymentGateway
             ),
         ));
         $response = json_decode(curl_exec($curl), true);
-        ray($response);
         // Check for cURL errors
         if (curl_errno($curl)) {
             throw new Exception('cURL error: ' . curl_error($curl));

--- a/easymerchant-givewp/easymerchant-givewp.php
+++ b/easymerchant-givewp/easymerchant-givewp.php
@@ -366,3 +366,11 @@ add_action('givewp_register_payment_gateway', static function ($paymentGatewayRe
     include 'class-easymerchant-gateway.php';
     $paymentGatewayRegister->registerGateway(EasyMerchantGateway::class);
 });
+
+// Register the gateways subscription module
+ add_filter("givewp_gateway_easymerchant-gateway_subscription_module", static function () {
+        include 'class-easymerchant-gateway-subscription-module.php';
+
+        return EasyMerchantGatewaySubscriptionModule::class;
+    }
+);


### PR DESCRIPTION
This updates support for v3 forms to use the hosted checkout.

NOTE: I did not find any documentation for recurring support for hosted checkout so not sure how that would work.  Some gateways will initiate a charge on the client and finish subscription logic on the server. Maybe that's the approach but i don't know.

This also scaffolds a new subscription module for creating recurring donations.

NOTE: All subscription logic lives in the subscription module via the `createSubscription` method.  All one-time payment logic lives in the original Gateway class `createPayment` method.

NOTE: This is not a complete implementation, just a starting point to get started.  This will need to be implemented correctly with knowledge of the easy merchant gateway api which i'm not familiar with.

NOTE: if you can avoid sending credit card details to the server it would be better as there is risk of PCI compliance.  it's better to use the hosted checkout solution whenever possible.